### PR TITLE
Allow non string data values

### DIFF
--- a/matchers/rendering_context.go
+++ b/matchers/rendering_context.go
@@ -2,10 +2,10 @@ package matchers
 
 type RenderingContext struct {
 	templates []string
-	data      map[string]string
+	data      map[string]interface{}
 }
 
-func (r RenderingContext) WithData(data map[string]string) RenderingContext {
+func (r RenderingContext) WithData(data map[string]interface{}) RenderingContext {
 	r.data = data
 	return r
 }


### PR DESCRIPTION
Co-authored-by: Michael Oleske <moleske@pivotal.io>
Co-authored-by: Dave Walter <dwalter@pivotal.io>

**Note**:  This is a breaking change for existing tests that test specific data values as they were previously always string values.