### PR TITLE
Allow making assertions on a deployment.Spec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,13 @@ module code.cloudfoundry.org/yttk8smatchers
 go 1.14
 
 require (
-	github.com/onsi/ginkgo v1.13.0
+	github.com/benjamintf1/unmarshalledmatchers v1.0.0
+	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
 	istio.io/client-go v0.0.0-20200814134724-bcbf0ed82b30
 	k8s.io/api v0.18.8
 	k8s.io/apiextensions-apiserver v0.18.8
 	k8s.io/apimachinery v0.18.8
 	k8s.io/client-go v11.0.0+incompatible
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/benjamintf1/unmarshalledmatchers v1.0.0 h1:JUhctHQVNarMXg5x3m0Tkp7WnDLzNVxeWc1qbKQPylI=
+github.com/benjamintf1/unmarshalledmatchers v1.0.0/go.mod h1:IVZdtAzpNyBTuhobduAjo5CjTLczWWbiXnWDVxIgSko=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
@@ -217,8 +219,8 @@ github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
-github.com/onsi/ginkgo v1.13.0 h1:M76yO2HkZASFjXL0HSoZJ1AYEmQxNJmY41Jx1zNUq1Y=
-github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1lskyM0=
+github.com/onsi/ginkgo v1.14.0 h1:2mOpI4JVVPBN+WQRa0WKH2eXR+Ey+uK4n7Zj0aYpIQA=
+github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
@@ -243,7 +245,6 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
-github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/matchers/with_deployment_matcher.go
+++ b/matchers/with_deployment_matcher.go
@@ -2,16 +2,20 @@ package matchers
 
 import (
 	"fmt"
+	"github.com/benjamintf1/unmarshalledmatchers"
 	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/types"
 	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/yaml"
 )
 
 type WithDeploymentMatcher struct {
 	name, namespace, errorMsg, errorMsgNotted string
 	matcher                                   types.GomegaMatcher
 	metas                                     []types.GomegaMatcher
+	specYaml                                  string
 	failedMatcher                             types.GomegaMatcher
+	failedMatcherActual                       interface{}
 }
 
 func WithDeployment(name, ns string) *WithDeploymentMatcher {
@@ -22,7 +26,13 @@ func WithDeployment(name, ns string) *WithDeploymentMatcher {
 	return &WithDeploymentMatcher{name: name, metas: metas}
 }
 
+func (matcher *WithDeploymentMatcher) WithSpecYaml(yaml string) *WithDeploymentMatcher {
+	matcher.specYaml = yaml
+	return matcher
+}
+
 func (matcher *WithDeploymentMatcher) Match(actual interface{}) (bool, error) {
+	matcher.failedMatcherActual = actual
 	docsMap, ok := actual.(map[string]interface{})
 	if !ok {
 		return false, fmt.Errorf("YAMLDocument must be passed a map[string]interface{}. Got\n%s", format.Object(actual, 1))
@@ -42,27 +52,43 @@ func (matcher *WithDeploymentMatcher) Match(actual interface{}) (bool, error) {
 			return ok, err
 		}
 	}
+
+	if matcher.specYaml != "" {
+		deploymentSpecYaml, err := yaml.Marshal(typedDeployment.Spec)
+		if err != nil {
+			return false, err
+		}
+
+		yamlMatcher := unmarshalledmatchers.ContainUnorderedYAML(matcher.specYaml)
+		ok, err = yamlMatcher.Match(deploymentSpecYaml)
+		if !ok || err != nil {
+			matcher.failedMatcher = yamlMatcher
+			matcher.failedMatcherActual = deploymentSpecYaml
+			return ok, err
+		}
+	}
+
 	return true, nil
 }
 
 func (matcher *WithDeploymentMatcher) FailureMessage(actual interface{}) string {
 	if matcher.failedMatcher == nil {
 		msg := fmt.Sprintf(
-			"FailureMessage: A statefulset with name %q doesnt exist",
+			"FailureMessage: A deployment with name %q doesnt exist",
 			matcher.name,
 		)
 		return msg
 	}
-	return matcher.failedMatcher.FailureMessage(actual)
+	return matcher.failedMatcher.FailureMessage(matcher.failedMatcherActual)
 }
 
 func (matcher *WithDeploymentMatcher) NegatedFailureMessage(actual interface{}) string {
 	if matcher.failedMatcher == nil {
 		msg := fmt.Sprintf(
-			"FailureMessage: A statefulset with name %q exists",
+			"FailureMessage: A deployment with name %q exists",
 			matcher.name,
 		)
 		return msg
 	}
-	return matcher.failedMatcher.NegatedFailureMessage(actual)
+	return matcher.failedMatcher.NegatedFailureMessage(matcher.failedMatcherActual)
 }

--- a/matchers/with_deployment_matcher.go
+++ b/matchers/with_deployment_matcher.go
@@ -85,9 +85,9 @@ func (matcher *WithDeploymentMatcher) FailureMessage(actual interface{}) string 
 func (matcher *WithDeploymentMatcher) NegatedFailureMessage(actual interface{}) string {
 	if matcher.failedMatcher == nil {
 		msg := fmt.Sprintf(
-			"FailureMessage: A deployment with name %q exists",
+			"FailureMessage: A deployment with name %q exists and/or the spec yaml was not correct %v",
 			matcher.name,
-		)
+			matcher.specYaml)
 		return msg
 	}
 	return matcher.failedMatcher.NegatedFailureMessage(matcher.failedMatcherActual)


### PR DESCRIPTION
This PR allows making an assertion on a deployment spec. 

for e.g:

```
Context("when cf-api-server.replicas is set", func() {
		BeforeEach(func() {
			data = map[string]interface{}{"resources.cf-api-server.replicas": 10}
		})

		It("should update the cf-api-server deployment replicas", func() {
			ctx = NewRenderingContext(templates...).WithData(data)
			Expect(ctx).To(ProduceYAML(WithDeployment("cf-api-server", "cf-system").WithSpecYaml(`replicas: 10`)))
		})

	})
```

It also fixes up the failure message thrown by the deployment matcher. (It would complain about a 'statefulset' when the matcher failed)